### PR TITLE
Removed react/jsx-tag-spacing rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,12 +45,6 @@ module.exports = {
         'ignore': ['navigation', 'navigationHelper'],
       },
     ],
-    'react/jsx-tag-spacing': {
-      'closingSlash': 'never',
-      'beforeSelfClosing': 'always',
-      'afterOpening': 'never',
-      'beforeClosing': 'allow',
-    },
     'radix': 0,
     'react/prefer-stateless-function': 0,
     'no-plusplus': 0,


### PR DESCRIPTION
It is the same as default value